### PR TITLE
Add use secondary roles

### DIFF
--- a/src/mcp_snowflake_server_formation/db_client.py
+++ b/src/mcp_snowflake_server_formation/db_client.py
@@ -35,6 +35,8 @@ class SnowflakeDB:
             if "warehouse" in self.connection_config:
                 self.session.sql(f"USE WAREHOUSE {self.connection_config['warehouse'].upper()}")
 
+            self.session.use_secondary_roles("ALL")
+
             self.auth_time = time.time()
         except Exception as e:
             raise ValueError(f"Failed to connect to Snowflake database: {e}")


### PR DESCRIPTION
Updates the initial connection point to tell snowflake to use all secondary roles by default for all connections.

Tested a bit by running the server and seeing it run ok, but not tested if it fixes issue yet.